### PR TITLE
Heroku Support!

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+bot: npm start
+web: echo PLEASE USE BOT AND NOT WEB!!!

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 **Discord bot written in NodeJS and Eris**
 
 Token and prefix are defined in config/local.json and is required for the bot to run (see config/default.json)
+
+## Deploy with Heroku!
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
+Optionally, deploy directly with this button to Heroku!
+Additional, use [this script](https://github.com/chaNcharge/ForkUpdater) to update your fork for a fully automated process!

--- a/app.json
+++ b/app.json
@@ -1,0 +1,33 @@
+{
+	"name": "lennartbot",
+	"description": "The best bot ever made, period.",
+	"website": "https://github.com/Stinjul/lennartbot",
+	"logo": "https://avatars0.githubusercontent.com/u/3649882",
+	"keywords": [
+		"discord",
+		"bot",
+		"lennart",
+		"gekoloniseerd",
+		"kokosnoot",
+		"pleur op"
+	],
+	"env": {
+		"DISCORD_TOKEN": {
+			"description": "Discord BOT token. Get it here: https://discordapp.com/developers/applications/."
+		},
+		"DISCORD_PREFIX": {
+			"description": "The prefix of your Lennart bot. E.g. summoning the bot is done via !help",
+			"value": "!"
+		}
+	},
+	"formation": {
+		"bot": {
+			"quantity": 1,
+			"size": "free"
+		},
+		"web": {
+			"quantity": 0,
+			"size": "free"
+		}
+	}
+}


### PR DESCRIPTION
This pull does the following:
Procfile: 
defines what workers exists. For node processes Heroku always defines a web worker. Withoud a $PORT variable, the bot dies in 90 seconds. Specifying a warning to use bot worker instead.

Readme: 
added deploy button relative to the repo it's viewed from (so forks use their code, not the master). Also added a note to use a special script to update a user's fork automatically, using Heroku.

app.json:
specifies what workers exists and also env variables for easy deployment (and more secure).